### PR TITLE
Small fix for setting the DateTimeFormat of an NZazu date-Field

### DIFF
--- a/NZazu.Xceed/XceedDateTimeField.cs
+++ b/NZazu.Xceed/XceedDateTimeField.cs
@@ -19,12 +19,17 @@ namespace NZazu.Xceed
             var control = new DateTimePickerWithUpdate { ToolTip = Definition.Description, Watermark = Definition.Hint };
 
             // set date time format
-            DateFormat = Definition.Settings.Get("Format");
+            DateFormat = Definition.Settings.Get(nameof(control.Format));
             // ReSharper disable once InvertIf
             if (!string.IsNullOrWhiteSpace(DateFormat))
             {
                 control.Format = DateTimeFormat.Custom;
                 control.FormatString = DateFormat;
+
+                if (Definition.Settings.ContainsKey(nameof(control.Format)))
+                {
+                    Definition.Settings[nameof(control.Format)] = Enum.GetName(typeof(DateTimeFormat), DateTimeFormat.Custom);
+                }
             }
 
             return control;


### PR DESCRIPTION
When the Field is created, it automatically sets the `DateTimeFormat` that is found inside of the provided Settings, and sets the wanted enum to `Custom`.

But with the Functions `SetProperty()` --> `GetConvertedValue()` inside of the class `PropertyExtensions` the Value will be checked again and will fail most of the time, because the `EnumConverter` is not able to convert the` DateFormatString` into an Enum, and will leave the users confused as to why an error is traced, but the Field with its Formats still works (because it was set before insode of `XceedDateTimeField`)
This change will fix that by setting the Format-Setting to the appropriate `Custom` DateTimeFormat-Enum