### PR TITLE
Provide Information for a failed SetProperty Attempt

### DIFF
--- a/NZazu/Fields/FieldFactoryExtensions.cs
+++ b/NZazu/Fields/FieldFactoryExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using NZazu.Contracts;
 using NZazu.Contracts.Checks;
@@ -23,8 +24,16 @@ namespace NZazu.Fields
 
             // apply generic settings
             var controlSettings = fieldDefinition.Settings.Where(s => control.CanSetProperty(s.Key));
-            foreach (var setting in controlSettings)
-                control.SetProperty(setting.Key, setting.Value);
+
+            try
+            {
+                foreach (var setting in controlSettings)
+                    control.SetProperty(setting.Key, setting.Value);
+            }
+            catch (ArgumentException exception)
+            {
+                Trace.TraceError($"Following error occured while setting the properties for the field <{field.Key}>: {Environment.NewLine}{exception}");
+            }
 
             return field;
         }

--- a/NZazu/Fields/NZazuField_Should.cs
+++ b/NZazu/Fields/NZazuField_Should.cs
@@ -281,20 +281,11 @@ namespace NZazu.Fields
         public void Handle_Empty_Property_Values(string propertyName)
         {
             var fieldDefinition = new FieldDefinition { Key = "test" };
-            Exception exception = null;
 
-            try
-            {
-                fieldDefinition.Settings.Add(propertyName, "");
-                var field = new NZazuField_With_Description_As_Content_Property(fieldDefinition, ServiceLocator);
-                field.ApplySettings(fieldDefinition);
-            }
-            catch (Exception e)
-            {
-                exception = e;
-            }
+            fieldDefinition.Settings.Add(propertyName, "");
+            var field = new NZazuField_With_Description_As_Content_Property(fieldDefinition, ServiceLocator);
 
-            exception.Should().BeNull();
+            Assert.DoesNotThrow(() => field.ApplySettings(fieldDefinition));
         }
     }
 }

--- a/NZazu/Fields/NZazuField_Should.cs
+++ b/NZazu/Fields/NZazuField_Should.cs
@@ -273,5 +273,28 @@ namespace NZazu.Fields
 
             Assert.DoesNotThrow(() => sut.Dispose());
         }
+
+        [Test]
+        [TestCase("Width")]
+        [TestCase("Height")]
+        [TestCase("Format")]
+        public void Handle_Empty_Property_Values(string propertyName)
+        {
+            var fieldDefinition = new FieldDefinition { Key = "test" };
+            Exception exception = null;
+
+            try
+            {
+                fieldDefinition.Settings.Add(propertyName, "");
+                var field = new NZazuField_With_Description_As_Content_Property(fieldDefinition, ServiceLocator);
+                field.ApplySettings(fieldDefinition);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+
+            exception.Should().BeNull();
+        }
     }
 }

--- a/NZazu/Fields/PropertyExtensions.cs
+++ b/NZazu/Fields/PropertyExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 
@@ -93,8 +92,8 @@ namespace NZazu.Fields
             }
             catch (Exception ex)
             {
-                Trace.TraceError("Could not convert the value \"{0}\" for property type \"{1}\" of prop \"{2}\": {3}", propValue, propInfo?.PropertyType.Name, propInfo?.Name, ex);
-                return null;
+                var message = $"Could not convert the value \"{propValue}\" for property type \"{propInfo?.PropertyType.Name}\" of prop \"{propInfo?.Name}\"";
+                throw new ArgumentException(message, ex);
             }
         }
     }


### PR DESCRIPTION
Before there were no information about which Field is failing to set its Properties. The Exception that is caught inside `PropertyExtension` will now be thrown again as an `ArgumentException` (because the caught Exception is always a  Base-Exception... which is not that optimal) and will be caught where the settings are actually applied. Here you'll have the ability to trace which field (with the key of that field) is affected, so searching for an error will be easier.

With these changes the output will be no different, except for the `Following error occured while setting the properties for the field <{field.Key}>` part...