### PR TITLE
Fix AutoCompleteManager's ResourceDictionary loading

### DIFF
--- a/NZazu/Fields/Libs/AutoCompleteManager.cs
+++ b/NZazu/Fields/Libs/AutoCompleteManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -99,7 +99,7 @@ namespace NZazu.Fields.Libs
 
             if (Application.Current == null) return; // because we are in testing
 
-            if (Application.Current.Resources.FindName("AcTb_ListBoxStyle") == null)
+            if (!Application.Current.Resources.Contains("AcTb_ListBoxStyle"))
             {
                 var myResourceDictionary = new ResourceDictionary();
                 // TODO: hard coded namespace. this can break on namespace changes! avoid that!


### PR DESCRIPTION
Previously the `ResourceDictionary` for the ListBox was added every single time the `AutoCompleteManager` was initialized, because the `FindName` Method of a `ResourceDictionary` was used. According to Microsoft's Documentation: 
https://docs.microsoft.com/de-de/dotnet/api/system.windows.resourcedictionary.findname?view=netframework-4.8
This Method always returns `null`, because Keys are used in a Dictionary. That's why this piece of code was faulty.
***
I've chagned this particular usage to "Contains" which uses the default Dictionary-approach. 
This also fixes a rare edge-case for me, where the private variable "_resizeGrip" would not be initialized and so will result in some `NullReferenceException`s