### PR TITLE
Prevent Multiple AutoComplete PopUps

### DIFF
--- a/NZazu/Fields/NZazuAutocompleteField.cs
+++ b/NZazu/Fields/NZazuAutocompleteField.cs
@@ -12,6 +12,7 @@ namespace NZazu.Fields
     internal class NZazuAutocompleteField : NZazuField<string>
     {
         private readonly IProvideSuggestions _suggester;
+        private bool _suggesterAttached;
 
         public NZazuAutocompleteField(FieldDefinition definition, Func<Type, object> serviceLocatorFunc)
             : base(definition, serviceLocatorFunc)
@@ -37,14 +38,20 @@ namespace NZazu.Fields
 
             // we have to do this on load because some wpf stuff does not work if no parent is set
             // i.e. some popup magic on window
-            result.Loaded += (sender, args) => { AttachSuggestor(sender); };
+            result.Loaded += (sender, args) =>
+            {
+                if (_suggesterAttached) return;
+                _suggesterAttached = true;
+
+                AttachSuggester(sender);
+            };
 
             return result;
         }
 
-        private void AttachSuggestor(object sender)
+        private void AttachSuggester(object sender)
         {
-// no suggester, no suggestions ;)
+            // no suggester, no suggestions ;)
             if (_suggester == null) return;
 
             var tb = (TextBox) sender;


### PR DESCRIPTION
In some rare cases it may happen, that the `Loaded` Event of the `TextBox` will be called twice. Because an `AutoCompleteManager` will be added to the `TextBox` each time the `Loaded` Event is fired, it may be added multiple times, resulting in having more than one `AutoCompleteManager`. Which results in displaying multiple popups, when the User writes something.

This change prevents this, as it "knows" if the `AutoCompleteManager` was already attached.