### PR TITLE
Fixes a Problem with wrong encoding of special chars for the richtext field

### DIFF
--- a/NZazu.Xceed/XceedRichTextField.cs
+++ b/NZazu.Xceed/XceedRichTextField.cs
@@ -1,6 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using NZazu.Contracts;
 using NZazu.Fields;
 using Xceed.Wpf.Toolkit;
@@ -15,6 +20,7 @@ namespace NZazu.Xceed
         public XceedRichTextField(FieldDefinition definition, Func<Type, object> serviceLocatorFunc)
             : base(definition, serviceLocatorFunc)
         {
+            ValueConverter = new RtfSpecialCharactersConverter();
         }
 
         public override DependencyProperty ContentProperty => RichTextBox.TextProperty;
@@ -49,4 +55,74 @@ namespace NZazu.Xceed
             }
         }
     }
+
+    #region converter
+
+    internal class RtfSpecialCharactersConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(value is string valueString)) return Binding.DoNothing;
+            if (targetType != typeof(string)) return Binding.DoNothing;
+
+            return FromPlainToRtf(valueString);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(value is string valueString)) return Binding.DoNothing;
+            if (targetType != typeof(string)) return Binding.DoNothing;
+
+            return FromRtfToPlain(valueString);
+        }
+
+        private static string FromPlainToRtf(string input)
+        {
+            var unicodeCharacterRegex = new Regex(@"[\p{L}-[A-Za-z]]");
+            var convertedValues = new List<char>();
+
+            foreach (Match match in unicodeCharacterRegex.Matches(input))
+            {
+                if (!match.Success) continue;
+
+                // we can safely convert to char here, because this regex only catches one char at a time
+                var matchValue = match.Value.FirstOrDefault();
+                if (convertedValues.Contains(matchValue)) continue; 
+
+                var converted = $"\\'{System.Convert.ToInt32(matchValue):X}".ToLower();
+
+                input = input.Replace(matchValue.ToString(), converted);
+                convertedValues.Add(matchValue);
+            }
+
+            return input;
+        }
+
+        private static string FromRtfToPlain(string input)
+        {
+            var rtfSpecialCharactersRegex = new Regex(@"(?<specialChar>\\{1,2}'[1-9,a-f]{2})");
+            var convertedValues = new List<string>();
+
+            foreach (Match match in rtfSpecialCharactersRegex.Matches(input))
+            {
+                if (!match.Success) continue;
+
+                var matchValue = match.Groups["specialChar"].Value;
+                if (convertedValues.Contains(matchValue)) continue;
+
+                // get only the part behind the ' , this indicates the hex-value for the char
+                var hexValue = matchValue.Substring(matchValue.IndexOf("'", StringComparison.InvariantCulture) + 1);
+                var @char = (char) short.Parse(hexValue, NumberStyles.AllowHexSpecifier);
+
+                // adjust the input string
+                input = input.Replace(matchValue, @char.ToString());
+                convertedValues.Add(matchValue);
+            }
+
+            return input;
+        }
+    }
+
+    #endregion
+
 }

--- a/NZazu.Xceed/XceedRichTextField_Should.cs
+++ b/NZazu.Xceed/XceedRichTextField_Should.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Threading;
 using System.Windows;
@@ -51,10 +51,10 @@ namespace NZazu.Xceed
             textBox.Text.Should().BeNullOrEmpty();
 
             field.SetValue("foobar");
-            textBox.Text.Should().Be(field.GetValue());
+            textBox.Text.Should().Contain(field.GetValue());
 
             textBox.Text = "not foobar";
-            field.GetValue().Should().Be(textBox.Text);
+            textBox.Text.Should().Contain(field.GetValue());
         }
 
         [Test]
@@ -149,6 +149,7 @@ namespace NZazu.Xceed
     internal class RtfSpecialCharactersConverter_Should
     {
         [Test]
+        [RequiresThread(ApartmentState.STA)]
         public void Be_Creatable()
         {
             var sut = new RtfSpecialCharactersConverter();
@@ -156,6 +157,7 @@ namespace NZazu.Xceed
         }
 
         [Test]
+        [RequiresThread(ApartmentState.STA)]
         public void Not_Convert_When_Invalid_Parameters()
         {
             var sut = new RtfSpecialCharactersConverter();
@@ -176,6 +178,7 @@ namespace NZazu.Xceed
         }
 
         [Test]
+        [RequiresThread(ApartmentState.STA)]
         public void Not_Convert_Back_When_Invalid_Parameters()
         {
             var sut = new RtfSpecialCharactersConverter();
@@ -196,6 +199,7 @@ namespace NZazu.Xceed
         }
 
         [Test]
+        [RequiresThread(ApartmentState.STA)]
         public void Convert_When_No_Special_Character()
         {
             var sut = new RtfSpecialCharactersConverter();
@@ -206,24 +210,26 @@ namespace NZazu.Xceed
             var result = sut.Convert(input, typeof(string), null, CultureInfo.CurrentCulture) as string;
 
             result.Should().NotBeNull();
-            result.Should().Be(expected);
+            result.Should().Contain(expected);
         }
 
         [Test]
+        [RequiresThread(ApartmentState.STA)]
         public void Convert_When_Special_Character()
         {
             var sut = new RtfSpecialCharactersConverter();
 
-            const string input = "some weird input string: ��� �";
+            const string input = "some weird input string: äöü ß";
             const string expected = "some weird input string: \\'e4\\'f6\\'fc \\'df";
 
             var result = sut.Convert(input, typeof(string), null, CultureInfo.CurrentCulture) as string;
 
             result.Should().NotBeNull();
-            result.Should().Be(expected);
+            result.Should().Contain(expected);
         }
 
         [Test]
+        [RequiresThread(ApartmentState.STA)]
         public void Convert_Back_When_No_Special_Character()
         {
             var sut = new RtfSpecialCharactersConverter();
@@ -238,14 +244,31 @@ namespace NZazu.Xceed
         }
 
         [Test]
+        [RequiresThread(ApartmentState.STA)]
         public void Convert_Back_When_Special_Character()
         {
             var sut = new RtfSpecialCharactersConverter();
 
             const string input = "some weird input string: \\'e4\\'f6\\'fc \\'df";
-            const string expected = "some weird input string: ��� �";
+            const string expected = "some weird input string: äöü ß";
 
             var result = sut.ConvertBack(input, typeof(string), null, CultureInfo.CurrentCulture) as string;
+
+            result.Should().NotBeNull();
+            result.Should().Be(expected);
+        }
+
+        [Test]
+        [RequiresThread(ApartmentState.STA)]
+        public void Convert_Back_And_Forth()
+        {
+            var sut = new RtfSpecialCharactersConverter();
+
+            // ReSharper disable once StringLiteralTypo
+            const string expected = "äöüß一個mộtля";
+
+            var converted = sut.Convert(expected, typeof(string), null, CultureInfo.CurrentCulture);
+            var result = sut.ConvertBack(converted, typeof(string), null, CultureInfo.CurrentCulture);
 
             result.Should().NotBeNull();
             result.Should().Be(expected);

--- a/NZazu.Xceed/XceedRichTextField_Should.cs
+++ b/NZazu.Xceed/XceedRichTextField_Should.cs
@@ -142,4 +142,115 @@ namespace NZazu.Xceed
             gistField.GetValue().Should().BeNullOrWhiteSpace("neither from or to has value that could be toggled");
         }
     }
+
+    #region converter tests
+
+    [TestFixtureFor(typeof(RtfSpecialCharactersConverter))]
+    internal class RtfSpecialCharactersConverter_Should
+    {
+        [Test]
+        public void Be_Creatable()
+        {
+            var sut = new RtfSpecialCharactersConverter();
+            sut.Should().NotBeNull();
+        }
+
+        [Test]
+        public void Not_Convert_When_Invalid_Parameters()
+        {
+            var sut = new RtfSpecialCharactersConverter();
+
+            object result = null;
+
+            Assert.DoesNotThrow(() => result = sut.Convert(null, typeof(string), null, CultureInfo.CurrentCulture));
+            result.Should().Be(Binding.DoNothing);
+
+            Assert.DoesNotThrow(() => result = sut.Convert(new object(), typeof(string), null, CultureInfo.CurrentCulture));
+            result.Should().Be(Binding.DoNothing);
+
+            Assert.DoesNotThrow(() => result = sut.Convert("some string", null, null, CultureInfo.CurrentCulture));
+            result.Should().Be(Binding.DoNothing);
+
+            Assert.DoesNotThrow(() => result = sut.Convert("some string", typeof(object), null, CultureInfo.CurrentCulture));
+            result.Should().Be(Binding.DoNothing);
+        }
+
+        [Test]
+        public void Not_Convert_Back_When_Invalid_Parameters()
+        {
+            var sut = new RtfSpecialCharactersConverter();
+
+            object result = null;
+
+            Assert.DoesNotThrow(() => result = sut.ConvertBack(null, typeof(string), null, CultureInfo.CurrentCulture));
+            result.Should().Be(Binding.DoNothing);
+            
+            Assert.DoesNotThrow(() => result = sut.ConvertBack(new object(), typeof(string), null, CultureInfo.CurrentCulture));
+            result.Should().Be(Binding.DoNothing);
+            
+            Assert.DoesNotThrow(() => result = sut.ConvertBack("some string", null, null, CultureInfo.CurrentCulture));
+            result.Should().Be(Binding.DoNothing);
+            
+            Assert.DoesNotThrow(() => result = sut.ConvertBack("some string", typeof(object), null, CultureInfo.CurrentCulture));
+            result.Should().Be(Binding.DoNothing);
+        }
+
+        [Test]
+        public void Convert_When_No_Special_Character()
+        {
+            var sut = new RtfSpecialCharactersConverter();
+
+            const string input = "some input string";
+            const string expected = "some input string";
+
+            var result = sut.Convert(input, typeof(string), null, CultureInfo.CurrentCulture) as string;
+
+            result.Should().NotBeNull();
+            result.Should().Be(expected);
+        }
+
+        [Test]
+        public void Convert_When_Special_Character()
+        {
+            var sut = new RtfSpecialCharactersConverter();
+
+            const string input = "some weird input string: äöü ß";
+            const string expected = "some weird input string: \\'e4\\'f6\\'fc \\'df";
+
+            var result = sut.Convert(input, typeof(string), null, CultureInfo.CurrentCulture) as string;
+
+            result.Should().NotBeNull();
+            result.Should().Be(expected);
+        }
+
+        [Test]
+        public void Convert_Back_When_No_Special_Character()
+        {
+            var sut = new RtfSpecialCharactersConverter();
+
+            const string input = "some input string";
+            const string expected = "some input string";
+
+            var result = sut.ConvertBack(input, typeof(string), null, CultureInfo.CurrentCulture) as string;
+
+            result.Should().NotBeNull();
+            result.Should().Be(expected);
+        }
+
+        [Test]
+        public void Convert_Back_When_Special_Character()
+        {
+            var sut = new RtfSpecialCharactersConverter();
+
+            const string input = "some weird input string: \\'e4\\'f6\\'fc \\'df";
+            const string expected = "some weird input string: äöü ß";
+
+            var result = sut.ConvertBack(input, typeof(string), null, CultureInfo.CurrentCulture) as string;
+
+            result.Should().NotBeNull();
+            result.Should().Be(expected);
+        }
+    }
+
+    #endregion
 }

--- a/NZazu/Fields/NZazuTextField.cs
+++ b/NZazu/Fields/NZazuTextField.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Remoting.Contexts;
 using System.Windows;
 using System.Windows.Controls;
 using NZazu.Contracts;


### PR DESCRIPTION
This commonly happens when someone would set the value of the field from the outside, to something like "ß", "ä", "ö", "ü" (and many other values). This also happens when this value is set through the `Values`-Part of the Form-Definition

Using this new Convert fixes this issue, by:
- Converting everything that counts as a special character in to the appropriate RTF-Encoded representation
- Converting back the RTF-Encoded special characters